### PR TITLE
Support publishing SVC catalogs as standalone pages too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Catalog file for auto-loading (should be created locally by users)
+catalog.json
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+*.tmp
+*.temp

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ The SVC examples in this repo were initially created with the following prompt u
 
 and attaching the first PDF.
 
-## Publishing a catalog
+## Publishing a single catalog
 
-For publishing at a public location, the SVC viewer can automatically display a specific catalog without requiring file selection. To publish a catalog for direct viewing:
+For publishing a single catalog at a public location, the SVC viewer can automatically display a specific catalog without requiring file selection. To publish a catalog for direct viewing:
 
-1. **Copy your SVC JSON file** to the same directory as `svc-viewer.html` and rename it to `catalog.json`. You may also want to rename `svc-viewer.html` to `index.html` at your serving location.
+1. **Copy your SVC JSON file** to the same directory as `svc-viewer.html` and rename it to `catalog.json`. You may also want to rename `svc-viewer.html` to `index.html` at your serving location, depending on your setup.
 
 2. **Serve the directory** using your webserver, or test with a simple web server:
    ```bash
@@ -84,11 +84,13 @@ This approach is fine for:
 - **Documentation**: Embed in websites or documentation
 - **Sharing**: Distribute a complete, self-contained viewer
 
+## Publishing multiple catalogs
+
 If you want to publish multiple catalogs then it would be better to:
 1. Extract the CSS style to a separate file,
-2. Serve the HTML with server-side rendering that sets the catalog to load and stylesheet to use based on the request location.
+2. Serve the HTML with server-side rendering that sets the catalog file to load and stylesheet to use based on the request location.
 
-This will enable a single html file to be maintained while the presentation branded for each catalog as required.
+This will enable a single html template file to be maintained while the presentation branded for each catalog as required.
 
 ## About SVC
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,46 @@ The SVC examples in this repo were initially created with the following prompt u
 
 and attaching the first PDF.
 
+## Publishing a catalog
+
+For publishing at a public location, the SVC viewer can automatically display a specific catalog without requiring file selection. To publish a catalog for direct viewing:
+
+1. **Copy your SVC JSON file** to the same directory as `svc-viewer.html` and rename it to `catalog.json`. You may also want to rename `svc-viewer.html` to `index.html` at your serving location.
+
+2. **Serve the directory** using your webserver, or test with a simple web server:
+   ```bash
+   # Using Python 3
+   python -m http.server 8000
+
+   # Using Python 2
+   python -m SimpleHTTPServer 8000
+
+   # Using Node.js
+   npx serve .
+
+   # Using PHP
+   php -S localhost:8000
+   ```
+
+3. **Open in browser**: Navigate to `http://localhost:8000/svc-viewer.html` or simply `http://localhost:8000/` if you renamed the html file to `index.html`.
+
+The viewer will automatically detect and display `catalog.json` without showing the file selector. If `catalog.json` is not present, it falls back to the normal file selection interface.
+
+### Customization
+
+You can customize the appearance by modifying the CSS styles in the HTML file.
+
+This approach is fine for:
+- **Demonstrations**: Show a specific catalog to stakeholders
+- **Documentation**: Embed in websites or documentation
+- **Sharing**: Distribute a complete, self-contained viewer
+
+If you want to publish multiple catalogs then it would be better to:
+1. Extract the CSS style to a separate file,
+2. Serve the HTML with server-side rendering that sets the catalog to load and stylesheet to use based on the request location.
+
+This will enable a single html file to be maintained while the presentation branded for each catalog as required.
+
 ## About SVC
 
 Sustainable Vocabulary Catalog (SVC) is a structured format for defining conformity schemes and their criteria. Read more at [UNTP Sustainable Vocabulary Catalog](https://uncefact.github.io/spec-untp/docs/specification/SustainabilityVocabularyCatalog).
@@ -68,3 +108,6 @@ Sustainable Vocabulary Catalog (SVC) is a structured format for defining conform
 
 **Problem**: Can't view files
 **Solution**: Ensure the JSON files are valid. The viewer will show an error message if the JSON is malformed.
+
+**Problem**: `catalog.json` doesn't auto-load
+**Solution**: Make sure you're serving the directory with a web server (not opening the HTML file directly). The auto-loading feature requires HTTP access to work due to browser security restrictions.

--- a/svc-viewer.html
+++ b/svc-viewer.html
@@ -513,7 +513,40 @@
             const fileInfo = document.getElementById("fileInfo");
             const svcContent = document.getElementById("svcContent");
 
+            // Check for catalog.json on page load
+            window.addEventListener("DOMContentLoaded", function () {
+                tryLoadCatalogJson();
+            });
+
             fileInput.addEventListener("change", handleFileSelect);
+
+            function tryLoadCatalogJson() {
+                // Check if fetch is available
+                if (typeof fetch === "undefined") {
+                    return; // Fall back to file selector
+                }
+
+                fetch("catalog.json")
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error("catalog.json not found");
+                        }
+                        return response.json();
+                    })
+                    .then((svcData) => {
+                        // Hide file selector and render the catalog
+                        const fileSelector =
+                            document.querySelector(".file-selector");
+                        if (fileSelector) {
+                            fileSelector.style.display = "none";
+                        }
+                        renderSVC(svcData);
+                    })
+                    .catch(() => {
+                        // Silently fail and show normal file selector
+                        // This is expected when catalog.json doesn't exist
+                    });
+            }
 
             function handleFileSelect(event) {
                 const file = event.target.files[0];

--- a/svc-viewer.html
+++ b/svc-viewer.html
@@ -486,7 +486,7 @@
             </div>
 
             <div class="content">
-                <div class="file-selector">
+                <div class="file-selector" id="fileSelector" style="display: none;">
                     <label for="fileInput" class="file-label">
                         📁 Select SVC JSON File
                     </label>
@@ -502,11 +502,10 @@
                     </div>
                 </div>
 
-                <div id="svcContent" class="no-data">
-                    Select an SVC JSON file to begin viewing its contents.
+                <div id="svcContent" class="loading">
+                    Checking for catalog...
                 </div>
             </div>
-        </div>
 
         <script>
             const fileInput = document.getElementById("fileInput");
@@ -523,7 +522,8 @@
             function tryLoadCatalogJson() {
                 // Check if fetch is available
                 if (typeof fetch === "undefined") {
-                    return; // Fall back to file selector
+                    showFileSelector();
+                    return;
                 }
 
                 fetch("catalog.json")
@@ -534,18 +534,24 @@
                         return response.json();
                     })
                     .then((svcData) => {
-                        // Hide file selector and render the catalog
-                        const fileSelector =
-                            document.querySelector(".file-selector");
-                        if (fileSelector) {
-                            fileSelector.style.display = "none";
-                        }
+                        // Render the catalog directly
                         renderSVC(svcData);
                     })
                     .catch(() => {
-                        // Silently fail and show normal file selector
-                        // This is expected when catalog.json doesn't exist
+                        // Show file selector when catalog.json doesn't exist
+                        showFileSelector();
                     });
+            }
+
+            function showFileSelector() {
+                const fileSelector = document.getElementById("fileSelector");
+                const svcContent = document.getElementById("svcContent");
+
+                if (fileSelector) {
+                    fileSelector.style.display = "block";
+                }
+
+                svcContent.innerHTML = '<div class="no-data">Select an SVC JSON file to begin viewing its contents.</div>';
             }
 
             function handleFileSelect(event) {


### PR DESCRIPTION
This PR updates the svc-viewer.html to support automatically loading a catalog json file when (a) the fetch API is present (ie. running on a web server) and (b) the file `catalog.json` is present in the same directory as the viewer.

I've updated the README with examples to match.